### PR TITLE
Minor tweaks to benchmarking run script.

### DIFF
--- a/run_benchmarks.bash
+++ b/run_benchmarks.bash
@@ -3,16 +3,16 @@ declare timeout=60
 declare -i amount_files=$1;
 declare -i total=4*3*amount_files*2*3;
 declare -i ctr=1;
-for ((c=0; c<=3; c++)); do
-    for ((r=1; r<=3; r++)); do
-        for ((i=1; i<=amount_files; i++)); do
-            for ((m=1; m<=3; m++)); do  # mode in which to run 1 -> normal, 2 -> macros, 3 -> deps
+for i in $(seq -f "%03g" 1 $amount_files); do
+    for ((c=0; c<=1; c++)); do
+        for ((r=1; r<=3; r++)); do
+            for ((m=1; m<=1; m++)); do  # mode in which to run 1 -> normal, 2 -> macros, 3 -> deps
                 for ((o=0; o<=1; o++)); do
-                    /usr/bin/time -o "/tmp/runtime" -f "%e" timeout "$timeout" ./smt_export "-g" "input-files/game/game-00$i.txt" "-n" "input-files/navgraph/navgraph-costs-00$i.csv" "-r" "$r" "-c" "$c" "-o" "$o" "--check" "$m" >> /dev/null
+                    /usr/bin/time -o "/tmp/runtime" -f "%e" timeout "$timeout" ./smt_export "-g" "input-files/game/game-$i.txt" "-n" "input-files/navgraph/navgraph-costs-$i.csv" "-r" "$r" "-c" "$c" "-o" "$o" "--check" "$m" &> /dev/null
                     if [ "$?" = "124" ]; then
-                        echo -e "$ctr/$total" \\t "Solved C$c R$r M$m o$o" \\t "TIMEOUT (${timeout}s)"
+                        echo -e "$i-C$c-R$r\\tM$m-o$o" \\t "__" \\t "${timeout}s"
                     else
-                        echo -e "$ctr/$total" \\t "Solved C$c R$r M$m o$o" \\t "$(cat /tmp/runtime)s"
+            			echo -e "$i-C$c-R$r\\tM$m-o$o" \\t "OK" \\t "$(cat /tmp/runtime)s"
                     fi
                     ctr=$((ctr+1))
                 done


### PR DESCRIPTION
Change the order in which experiments are run and support games beyond 1-9.
Benchmarks are limited to complexity 0/1 and the "pure" configuration of the planner.

Somehow I am not allowed to push directly to this repository, hence the pull request =)